### PR TITLE
refactor(graphql): refactor luminosity option into enum type

### DIFF
--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -34,6 +34,12 @@ export default gql`
     simple
   }
 
+  enum Luminosity {
+    bright
+    light
+    dark
+  }
+
   input Options {
     """
     The dimensions of the svg. Defaults to 20.
@@ -62,7 +68,7 @@ export default gql`
     """
     Controls the luminosity of the generated color. You can specify a string containing bright, light or dark.
     """
-    luminosity: String
+    luminosity: Luminosity
     """
     An integer or string which when passed will cause randomColor to return the same color each time.
     """


### PR DESCRIPTION
Since the `luminosity` field on `Options` only accepts specific values,
using an enum type for it (`Luminosity`) makes sense.